### PR TITLE
fix: Remove 'Wait for MAAS boot resources' step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,3 @@ runs:
       run: |
         set -x
         sudo maas init region+rack --maas-url=${{inputs.maas-url}} --database-uri maas-test-db:///
-    - name: Wait for MAAS boot resources
-      shell: bash
-      run: while [ $(maas admin boot-resources is-importing | cat) == "true" ]; do sleep 10; done; echo "syncing finished"


### PR DESCRIPTION
This step seems to be what's causing the issues in sitespeed on MAAS UI, since it's trying to use an admin command without logging in. We have this step in the sitespeed workflow anyway, and we run it *after* logging in with a known username and password.